### PR TITLE
[v0.3] Fix critical logic bug in merging watershed transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /true/
 /Cargo.lock
+/.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
-![rustronomy_dark_banner](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_dark.png?raw=true#gh-light-mode-only)
-![rustronomy_light_banner](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_light.png#gh-dark-mode-only)
+![](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_dark.png?raw=true#gh-light-mode-only)
+![](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_light.png#gh-dark-mode-only)
 # rustronomy-watershed changelog
+
+## v0.3.0
+This version does not contain any breaking API changes, but it fixes a *major*
+bug in the merging watershed transforms. Previously, there was some randomisation
+of the "colours" of certain lakes which caused random lakes to merge, even if 
+they were not touching. This has been fixed.
+
+In addition, a new utility function has been added: `pre_processor_with_max`. This function can be used as a replacement for the pre-processor if you want to normalise the input to the water transform to a different range than `1..u8::MAX-1`, like so:
+```rust
+use rustronomy_watershed::prelude::*;
+use ndarray_rand::{rand_distr::Uniform, RandomExt};
+///
+//Set custom maximum waterlevel
+const MY_MAX: u8 = 127;
+
+//Create a random uniform distribution
+let rf = nd::Array2::<f64>::random((512, 512), Uniform::new(0.0, 1.0));
+
+//Set-up the watershed transform
+let watershed = TransformBuilder::new_segmenting()
+    .set_max_water_lvl(MY_MAX)
+    .build()
+    .unwrap();
+
+//Run pre-processor (using turbofish syntax)
+let rf = watershed.pre_processor_with_max::<{MYMAX}, _, _>(rf.view());
+
+//Find minima of the random field (to be used as seeds)
+let rf_mins = watershed.find_local_minima(rf.view());
+//Execute the watershed transform
+let output = watershed.transform(rf.view(), &rf_mins)
+```
+The braces in `{MYMAX}` are necessary for the code to compile. This is an unfortunate limitation of rustc, which may get fixed in the future. For now, just use curly braces!
 
 ## v0.2.0
 Updated `Watershed` trait (public API breaking change)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ keywords = ["astronomy", "astrophysics", "rustronomy", "image-processing", "wate
 categories = ["science", "algorithms"]
 
 [features]
-default = []
+default = ["jemalloc", "plots", "debug"]
 jemalloc = ["dep:jemallocator"]
 plots = ["dep:plotters"]
 progress = ["dep:indicatif"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ rand = "0.8"
 
 [dev-dependencies]
 ndarray-rand = "0.14"
+rand = "0.8"
 rustronomy-fits = "0.2"
 
 [package.metadata.cargo-all-features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@
 
 [package]
 name = "rustronomy-watershed"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 readme = "./README.md"
 license = "EUPL-1.2"
@@ -34,7 +34,7 @@ keywords = ["astronomy", "astrophysics", "rustronomy", "image-processing", "wate
 categories = ["science", "algorithms"]
 
 [features]
-default = ["jemalloc", "plots", "debug", "progress"]
+default = []
 jemalloc = ["dep:jemallocator"]
 plots = ["dep:plotters"]
 progress = ["dep:indicatif"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ keywords = ["astronomy", "astrophysics", "rustronomy", "image-processing", "wate
 categories = ["science", "algorithms"]
 
 [features]
-default = ["jemalloc", "plots", "debug"]
+default = ["jemalloc", "plots", "debug", "progress"]
 jemalloc = ["dep:jemallocator"]
 plots = ["dep:plotters"]
 progress = ["dep:indicatif"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![rustronomy_dark_banner](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_dark.png?raw=true#gh-light-mode-only)
-![rustronomy_light_banner](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_light.png#gh-dark-mode-only)
+![](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_dark.png?raw=true#gh-light-mode-only)
+![](https://github.com/smups/rustronomy/blob/main/logos/Rustronomy-watershed_github_banner_light.png#gh-dark-mode-only)
 # The Rustronomy watershed - a pure rust implementation of the segmenting and merging watershed algorithms
 [![License: EUPL v1.2](https://img.shields.io/badge/License-EUPLv1.2-blue.svg)](https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12)
 [![Crates.io](https://img.shields.io/crates/v/rustronomy-watershed)](https://crates.io/crates/rustronomy-watershed)
@@ -37,6 +37,9 @@ To use Rustronomy-fits in a Jupyter notebook, execute a cell containing the foll
 ```rust
 :dep rustronomy-watershed = {version = "0.1"}
 ```
+
+> Please do not use any versions before 0.3, as they contain a major bug in the implementation of the merging watershed algorithm
+
 If you want to use the latest (unstable) development version of `rustronomy-watershed`, you can do so by using the `git` field (which fetches the latest version from the repo) rather than the `version` field (which downloads the latest released version from crates.io). 
 ```
 {git = "https://github.com/smups/rustronomy-watershed"}

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ below](#cargo-feature-gates).
 To use the latest release of Rustronomy-watershed in a cargo project, add the rustronomy-watershed crate as a dependency to your `Cargo.toml` file:
 ```toml
 [dependencies]
-rustronomy-watershed = "0.1.0"
+rustronomy-watershed = "0.3"
 ```
 To use Rustronomy-fits in a Jupyter notebook, execute a cell containing the following code:
 ```rust
-:dep rustronomy-watershed = {version = "0.1"}
+:dep rustronomy-watershed = {version = "0.3"}
 ```
 
 > Please do not use any versions before 0.3, as they contain a major bug in the implementation of the merging watershed algorithm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,36 @@ fn make_colour_map(base_map: &mut [usize], local_mergers: Vec<Vec<usize>>) {
   }
 }
 
+#[test]
+fn test_make_colour_map() {
+  //This test assumes UNCOLOURED == 0, so it should fail
+  assert!(UNCOLOURED == 0);
+  let mut cmap;
+  
+  //Test merging of once-connected region
+  cmap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  make_colour_map(&mut cmap, vec![vec![1,2]]);
+  assert!(cmap == [0, 1, 1, 3, 4, 5, 6, 7, 8, 9]);
+  
+  //Now test multiple non-connected regions
+  cmap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  make_colour_map(&mut cmap, vec![vec![1,2], vec![8,9]]);
+  assert!(cmap == [0, 1, 1, 3, 4, 5, 6, 7, 8, 8]);
+
+  //Now test multiple *connected* regions
+  cmap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  make_colour_map(&mut cmap, vec![vec![1,2], vec![2,3]]);
+  assert!(cmap == [0, 1, 1, 1, 4, 5, 6, 7, 8, 9]);
+
+  //Two consecutive mergers
+  cmap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  make_colour_map(&mut cmap, vec![vec![1,2], vec![8,9]]);
+  dbg!(&cmap);
+  make_colour_map(&mut cmap, vec![vec![1,7], vec![7,8]]);
+  dbg!(&cmap);
+  assert!(cmap == [0, 1, 1, 3, 4, 5, 6, 1, 1, 1]);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //                             OPTIONAL MODULES                               //
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,13 +385,16 @@ fn make_colour_map(base_map: &mut [usize], local_mergers: Vec<Vec<usize>>) {
     connected_mergers.push(new_region);
     connected_mergers = connected_mergers
       .into_iter()
-      .filter_map(|region| if region.is_empty() { None } else { Some(region) })
+      .filter(|region| !region.is_empty())
       .collect();
   }
 
   for merge in connected_mergers {
     let merged_col = *merge.get(0).expect("tried to merge zero regions");
-    merge.into_iter().for_each(|original| base_map[original] = merged_col)
+    base_map
+      .iter_mut()
+      .filter(|x| merge.contains(x))
+      .for_each(|x| *x = merged_col);
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,9 +578,7 @@ fn test_make_colour_map() {
   //Two consecutive mergers
   cmap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   make_colour_map(&mut cmap, &vec![Merge([1,2]), Merge([8,9])]);
-  dbg!(&cmap);
   make_colour_map(&mut cmap, &vec![Merge([1,7]), Merge([7,8])]);
-  dbg!(&cmap);
   assert!(cmap == [0, 1, 1, 3, 4, 5, 6, 1, 1, 1]);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@
 //! new watershed transform, one can use the `TransformBuilder` struct which is
 //! included in the `rustronomy_watershed` prelude.
 //! ```rust
+//! use ndarray as nd;
 //! use rustronomy_watershed::prelude::*;
 //! use ndarray_rand::{rand_distr::Uniform, RandomExt};
 //!
@@ -80,7 +81,7 @@
 //! //Find minima of the random field (to be used as seeds)
 //! let rf_mins = watershed.find_local_minima(rf.view());
 //! //Execute the watershed transform
-//! let output = watershed.transform(rf.view(), &rf_mins)
+//! let output = watershed.transform(rf.view(), &rf_mins);
 //! ```
 //! [^1]: H. Digabel and C. Lantuéjoul. **Iterative algorithms.** *In Actes du Second Symposium Européen d’Analyse Quantitative des Microstructures en Sciences des Matériaux, Biologie et Medécine*, October 1978.
 //!
@@ -826,7 +827,7 @@ pub trait WatershedUtils {
   ///     .unwrap();
   /// 
   /// //Run pre-processor (using turbofish syntax)
-  /// let rf = watershed.pre_processor_with_max::<MYMAX, _, _>(rf.view());
+  /// let rf = watershed.pre_processor_with_max::<{MYMAX}, _, _>(rf.view());
   /// 
   /// //Find minima of the random field (to be used as seeds)
   /// let rf_mins = watershed.find_local_minima(rf.view());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,16 @@ fn sort_by_small_big(this: &Merge, that: &Merge) -> std::cmp::Ordering {
   }
 }
 
+#[test]
+fn test_merge_ord_small_big() {
+  use std::cmp::Ordering::*;
+  let cmp = sort_by_small_big;
+  assert_eq!(cmp(&Merge([2, 1]), &Merge([1,1])), Greater);
+  assert_eq!(cmp(&Merge([1, 1]), &Merge([1,2])), Less);
+  assert_eq!(cmp(&Merge([2, 1]), &Merge([1,2])), Equal);
+  assert_eq!(cmp(&Merge([3, 8]), &Merge([4,5])), Less);
+}
+
 #[inline(always)]
 fn sort_by_big_small(this: &Merge, that: &Merge) -> std::cmp::Ordering {
   use std::cmp::Ordering::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,11 @@ impl From<[usize; 2]> for Merge {
   fn from(value: [usize; 2]) -> Self { Self(value) }
 }
 
+impl From<Merge> for [usize; 2] {
+  #[inline(always)]
+  fn from(value: Merge) -> Self { value.0 }
+}
+
 fn find_merge(col: nd::ArrayView2<usize>) -> Vec<Merge> {
   //Window size and index of center window pixel
   const WINDOW: (usize, usize) = (3, 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,39 @@ fn find_px(
     .collect()
 }
 
+#[test]
+fn test_find_px() {
+  //This test assumes UNCOLOURED == 0, so it should fail
+  assert!(UNCOLOURED == 0);
+  let input = nd::array![
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 1, 0, 0],
+    [0, 0, 1, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 5, 0, 0],
+    [0, 0, 0, 1, 0, 0, 0, 0],
+    [0, 0, 0, 5, 0, 0, 1, 0],
+    [0, 0, 5, 4, 5, 0, 0, 0],
+    [0, 0, 0, 5, 0, 0, 0, 0],
+  ];
+  let colours = nd::array![
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 1, 1, 1, 1, 0, 1, 0],
+    [0, 1, 0, 1, 1, 1, 1, 0],
+    [0, 1, 1, 1, 1, 0, 1, 0],
+    [0, 1, 1, 1, 0, 0, 1, 0],
+    [0, 1, 1, 0, 1, 1, 0, 0],
+    [0, 1, 0, 0, 0, 1, 1, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0]
+  ];
+  let answer1 = [(1,5), (2,2), (4,4), (5,6)];
+  let attempt1 = find_px(input.view(), colours.view(), 2)
+    .into_iter().map(|(x, _)| x)
+    .collect::<Vec<_>>();
+  for answer in answer1 {
+    assert!(attempt1.contains(&answer))
+  }
+}
+
 fn find_merge(col: nd::ArrayView2<usize>) -> Vec<Vec<usize>> {
   //Window size and index of center window pixel
   const WINDOW: (usize, usize) = (3, 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1355,7 +1355,7 @@ impl Watershed for MergingWatershed {
       .collect()
   }
 
-  fn transform(&self, input: nd::ArrayView2<u8>, seeds: &[(usize, usize)]) -> nd::Array2<usize> {
+  fn transform(&self, input: nd::ArrayView2<u8>, _seeds: &[(usize, usize)]) -> nd::Array2<usize> {
     //Note: the implementation of `transform` is trivial for the merging transfo
 
     //(1) make an image for holding the different water colours

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1256,14 +1256,7 @@ impl Watershed for MergingWatershed {
             //No more connected, flooded pixels left -> raise water level
             break 'colouring_loop;
           } else {
-            /*We have pixels to colour
-              I have to discuss safety for a moment. Since we iterated over all
-              pixels and only allowed a pixel to set its own colour, we know that
-              there is at most one colour instruction per pixel. Since the pixels
-              do not overlap in memory, we can safely access each pixel concurrently.
-              To do this, I temporarily put the output watershed canvas in a global
-              static variable that can be accessed from any thread.
-            */
+            //We have pixels to colour
             #[cfg(feature = "debug")]
             let colour_start = std::time::Instant::now();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,11 @@ impl PartialEq for Merge {
   }
 }
 
+#[test]
+fn test_merge_eq() {
+  assert_eq!(Merge([1,2]), Merge([2,1]));
+}
+
 #[inline(always)]
 fn sort_by_small_big(this: &Merge, that: &Merge) -> std::cmp::Ordering {
   use std::cmp::Ordering::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1221,11 +1221,8 @@ impl Watershed for MergingWatershed {
     let mut output = nd::Array2::<usize>::zeros(shape);
 
     //(2) set "colours" for each of the starting points
-    // The colours should range from 1 to seeds.len(), but which seed gets which
-    // colour should be random, so we shuffle the vec.
-    // One important excpetion is the zeroth element. It should be set to zero
-    let mut colours: Vec<usize> = seeds.iter().enumerate().map(|(idx, _)| idx + 1).collect();
-    colours.shuffle(&mut rand::thread_rng());
+    // The colours should range from 1 to seeds.len()
+    let mut colours: Vec<usize> = (1..=seeds.len()).into_iter().collect();
 
     //Colour the starting pixels
     for (&idx, &col) in seeds.iter().zip(colours.iter()) {
@@ -1412,11 +1409,8 @@ impl Watershed for MergingWatershed {
     let mut output = nd::Array2::<usize>::zeros(shape);
 
     //(2) set "colours" for each of the starting points
-    // The colours should range from 1 to seeds.len(), but which seed gets which
-    // colour should be random, so we shuffle the vec.
-    // One important excpetion is the zeroth element. It should be set to zero
-    let mut colours: Vec<usize> = seeds.iter().enumerate().map(|(idx, _)| idx + 1).collect();
-    colours.shuffle(&mut rand::thread_rng());
+    // The colours should range from 1 to seeds.len()
+    let mut colours: Vec<usize> = (1..=seeds.len()).into_iter().collect();
 
     //Colour the starting pixels
     for (&idx, &col) in seeds.iter().zip(colours.iter()) {
@@ -1629,11 +1623,8 @@ impl Watershed for SegmentingWatershed {
     let mut output = nd::Array2::<usize>::zeros(shape);
 
     //(2) set "colours" for each of the starting points
-    // The colours should range from 1 to seeds.len(), but which seed gets which
-    // colour should be random, so we shuffle the vec.
-    // One important excpetion is the zeroth element. It should be set to zero
-    let mut colours: Vec<usize> = seeds.iter().enumerate().map(|(idx, _)| idx + 1).collect();
-    colours.shuffle(&mut rand::thread_rng());
+    // The colours should range from 1 to seeds.len()
+    let mut colours: Vec<usize> = (1..=seeds.len()).into_iter().collect();
 
     //Colour the starting pixels
     for (&idx, &col) in seeds.iter().zip(colours.iter()) {
@@ -1772,11 +1763,8 @@ impl Watershed for SegmentingWatershed {
     let mut output = nd::Array2::<usize>::zeros(shape);
 
     //(2) set "colours" for each of the starting points
-    // The colours should range from 1 to seeds.len(), but which seed gets which
-    // colour should be random, so we shuffle the vec.
-    // One important excpetion is the zeroth element. It should be set to zero
-    let mut colours: Vec<usize> = seeds.iter().enumerate().map(|(idx, _)| idx + 1).collect();
-    colours.shuffle(&mut rand::thread_rng());
+    // The colours should range from 1 to seeds.len()
+    let mut colours: Vec<usize> = (1..=seeds.len()).into_iter().collect();
 
     //Colour the starting pixels
     for (&idx, &col) in seeds.iter().zip(colours.iter()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,16 @@ fn sort_by_big_small(this: &Merge, that: &Merge) -> std::cmp::Ordering {
   }
 }
 
+#[test]
+fn test_merge_ord_big_small() {
+  use std::cmp::Ordering::*;
+  let cmp = sort_by_big_small;
+  assert_eq!(cmp(&Merge([2, 1]), &Merge([1,1])), Greater);
+  assert_eq!(cmp(&Merge([1, 1]), &Merge([1,2])), Less);
+  assert_eq!(cmp(&Merge([2, 1]), &Merge([1,2])), Equal);
+  assert_eq!(cmp(&Merge([3, 8]), &Merge([4,5])), Greater);
+}
+
 impl From<[usize; 2]> for Merge {
   #[inline(always)]
   fn from(value: [usize; 2]) -> Self { Self(value) }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -26,6 +26,7 @@ use ndarray_rand::{
   rand_distr::{Poisson, Uniform},
   RandomExt,
 };
+#[cfg(feature = "plots")]
 use plotters::style::RGBColor;
 use rand::Rng;
 use rustronomy_fits as rsf;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -26,6 +26,8 @@ use ndarray_rand::{
   rand_distr::{Poisson, Uniform},
   RandomExt,
 };
+use plotters::style::RGBColor;
+use rand::Rng;
 use rustronomy_fits as rsf;
 use rustronomy_watershed::prelude::*;
 
@@ -42,6 +44,15 @@ fn get_root_path() -> std::path::PathBuf {
   std::path::Path::new(&root_path)
     .canonicalize()
     .expect(&format!("could not canonicalize path found in ${DATA_ENV} env. variable"))
+}
+
+#[cfg(feature = "plots")]
+fn cmap(_count: usize, _min: usize, _max: usize) -> Result<RGBColor, Box<dyn std::error::Error>> {
+  Ok(RGBColor(
+    rand::thread_rng().gen_range(25..u8::MAX),
+    rand::thread_rng().gen_range(25..u8::MAX),
+    rand::thread_rng().gen_range(25..u8::MAX)
+  ))
 }
 
 fn open_cgps() {
@@ -103,7 +114,11 @@ fn test_merging_uniform() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_merging().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_merging()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //find minima
   let mins = &watershed.find_local_minima(rf.view());
@@ -131,7 +146,11 @@ fn test_segmenting_uniform() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_segmenting().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_segmenting()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //find minima
   let mins = &watershed.find_local_minima(rf.view());
@@ -159,7 +178,11 @@ fn test_merging_poisson() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_merging().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_merging()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let rf = watershed.pre_processor(rf.view());
@@ -188,7 +211,11 @@ fn test_segmenting_poisson() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_segmenting().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_segmenting()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let rf = watershed.pre_processor(rf.view());
@@ -228,7 +255,11 @@ fn test_merging_real() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_merging().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_merging()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(img.view());
@@ -268,7 +299,11 @@ fn test_segmenting_real() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_segmenting().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_segmenting()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(img.view());
@@ -308,7 +343,11 @@ fn test_merging_real_with_nan() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_merging().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_merging()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(img.view());
@@ -348,7 +387,11 @@ fn test_segmenting_real_with_nan() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_segmenting().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_segmenting()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(img.view());
@@ -374,7 +417,11 @@ fn test_merging_gaussian() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_merging().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_merging()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(
@@ -412,7 +459,11 @@ fn test_segmenting_gaussian() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_segmenting().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_segmenting()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(
@@ -464,7 +515,11 @@ fn test_merging_real_smoothed() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_merging().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_merging()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(img.view());
@@ -504,7 +559,11 @@ fn test_segmenting_real_smoothed() {
   if !root.exists() {
     std::fs::create_dir(&root).unwrap();
   }
-  let watershed = TransformBuilder::new_segmenting().set_plot_folder(&root).build().unwrap();
+  let watershed = TransformBuilder::new_segmenting()
+    .set_plot_folder(&root)
+    .set_plot_colour_map(cmap)
+    .build()
+    .unwrap();
 
   //run pre-processor and find minima
   let img = watershed.pre_processor(img.view());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,7 +19,7 @@
   licensee subject to Dutch law as per article 15 of the EUPL.
 */
 
-use std::sync::RwLock;
+use std::sync::{RwLock, Mutex, Arc};
 
 use ndarray as nd;
 use ndarray_rand::{
@@ -46,13 +46,21 @@ fn get_root_path() -> std::path::PathBuf {
     .expect(&format!("could not canonicalize path found in ${DATA_ENV} env. variable"))
 }
 
+static CMAP: Mutex<Vec<(u8, u8, u8)>> = Mutex::new(Vec::new());
+
+#[inline]
 #[cfg(feature = "plots")]
-fn cmap(_count: usize, _min: usize, _max: usize) -> Result<RGBColor, Box<dyn std::error::Error>> {
-  Ok(RGBColor(
-    rand::thread_rng().gen_range(25..u8::MAX),
-    rand::thread_rng().gen_range(25..u8::MAX),
-    rand::thread_rng().gen_range(25..u8::MAX)
-  ))
+fn cmap(count: usize, _min: usize, _max: usize) -> Result<RGBColor, Box<dyn std::error::Error>> {
+  let mut cols = CMAP.lock().unwrap();
+  if cols.is_empty() { cols.push((0,0,0)) }
+  if let Some(c) = cols.get(count) {
+    Ok(RGBColor(c.0, c.1, c.2))
+  } else {
+    let mut rng = rand::thread_rng();
+    let c = (rng.gen_range(25..u8::MAX), rng.gen_range(25..u8::MAX), rng.gen_range(25..u8::MAX));
+    cols.push(c.clone());
+    Ok(RGBColor(c.0, c.1, c.2))
+  }
 }
 
 fn open_cgps() {
@@ -132,7 +140,7 @@ fn test_merging_uniform() {
   .unwrap();
 
   //Do transform
-  watershed.transform(rf.view(), mins);
+  watershed.transform_to_list(rf.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -164,7 +172,7 @@ fn test_segmenting_uniform() {
   .unwrap();
 
   //Do transform
-  watershed.transform(rf.view(), mins);
+  watershed.transform_to_list(rf.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -197,7 +205,7 @@ fn test_merging_poisson() {
   .unwrap();
 
   //Do transform
-  watershed.transform(rf.view(), mins);
+  watershed.transform_to_list(rf.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -230,7 +238,7 @@ fn test_segmenting_poisson() {
   .unwrap();
 
   //Do transform
-  watershed.transform(rf.view(), mins);
+  watershed.transform_to_list(rf.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -274,7 +282,7 @@ fn test_merging_real() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -318,7 +326,7 @@ fn test_segmenting_real() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -362,7 +370,7 @@ fn test_merging_real_with_nan() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -406,7 +414,7 @@ fn test_segmenting_real_with_nan() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -448,7 +456,7 @@ fn test_merging_gaussian() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -490,7 +498,7 @@ fn test_segmenting_gaussian() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -534,7 +542,7 @@ fn test_merging_real_smoothed() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }
 
 #[cfg(feature = "plots")]
@@ -578,5 +586,5 @@ fn test_segmenting_real_smoothed() {
   .unwrap();
 
   //Do transform
-  watershed.transform(img.view(), mins);
+  watershed.transform_to_list(img.view(), mins);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,7 +19,7 @@
   licensee subject to Dutch law as per article 15 of the EUPL.
 */
 
-use std::sync::{RwLock, Mutex, Arc};
+use std::sync::{RwLock, Mutex};
 
 use ndarray as nd;
 use ndarray_rand::{


### PR DESCRIPTION
Version bump to 0.3:

This version does not contain any breaking API changes, but it fixes a *major*
bug in the merging watershed transforms. Previously, there was some randomisation
of the "colours" of certain lakes which caused random lakes to merge, even if 
they were not touching. This has been fixed.

In addition, a new utility function has been added: `pre_processor_with_max`. This function can be used as a replacement for the pre-processor if you want to normalise the input to the water transform to a different range than `1..u8::MAX-1`, like so:
```rust
use rustronomy_watershed::prelude::*;
use ndarray_rand::{rand_distr::Uniform, RandomExt};
///
//Set custom maximum waterlevel
const MY_MAX: u8 = 127;

//Create a random uniform distribution
let rf = nd::Array2::<f64>::random((512, 512), Uniform::new(0.0, 1.0));

//Set-up the watershed transform
let watershed = TransformBuilder::new_segmenting()
    .set_max_water_lvl(MY_MAX)
    .build()
    .unwrap();

//Run pre-processor (using turbofish syntax)
let rf = watershed.pre_processor_with_max::<{MYMAX}, _, _>(rf.view());

//Find minima of the random field (to be used as seeds)
let rf_mins = watershed.find_local_minima(rf.view());
//Execute the watershed transform
let output = watershed.transform(rf.view(), &rf_mins)
```
The braces in `{MYMAX}` are necessary for the code to compile. This is an unfortunate limitation of rustc, which may get fixed in the future. For now, just use curly braces!