### PR TITLE
Permit passing colors with seeds, to allow multiple seeds per color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ debug = []
 
 [dependencies]
 #Arrays and parallel array iterators
-ndarray = {version="0.15", features=["rayon"]}
+ndarray = {version="0.16", features=["rayon"]}
 
 #Better allocator
 jemallocator = { version = "0.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1677,7 +1677,7 @@ impl<T> SegmentingWatershed<T> {
     }
 
     #[cfg(feature = "debug")]
-    println!("starting with {} lakes", colours.len());
+    println!("starting with {} lakes", seeds_with_colours.len());
 
     //(3) set-up progress bar
     #[cfg(feature = "progress")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1632,7 +1632,12 @@ impl<T> SegmentingWatershed<T> {
     }
   }
 
-  fn transform_with_hook_and_colours(
+  /// Transform the image, with seeds labeled by colours.
+  ///
+  /// This differs from transform_with_hook in that you can specify nonconsecutive colours,
+  /// or multiple seeds with the same colour. Seeds with the color 0 will be treated as uncoloured,
+  /// which is equivalent to providing no seed at all.
+  pub fn transform_with_hook_and_colours(
     &self,
     input: nd::ArrayView2<u8>,
     seeds_with_colours: &[(usize, (usize, usize))],


### PR DESCRIPTION
This was the smallest change I could think of that would allow labeling multiple seeds with the same color, which is useful for CV for segmenting objects that have many local extrema. It uses the same data structure as the algorithm does internally, and it is only exposed for the Segmenting Watershed because I can't think of why you would want to do this with MergingWatershed but We could move it to the trait instead if that makes sense